### PR TITLE
Load mail credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ A simple, styled file uploader built in Flask to route design files directly to 
 ```bash
 git clone https://github.com/Droid80sa/Designer-Upload.git
 cd Designer-Upload
+```
+
+### 🔑 Environment Variables
+
+Create a `.env` file with:
+
+```bash
+SECRET_KEY=supersecret
+MAIL_USERNAME=proofs@hotink.co.za
+MAIL_PASSWORD=your_password
+```
+
+The `docker-compose.yml` file and `config.py` load these variables when running locally.

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ class Config:
     MAIL_SERVER = 'smtp.hotink.co.za'
     MAIL_PORT = 465
     MAIL_USE_SSL = True
-    MAIL_USERNAME = 'proofs@hotink.co.za'
-    MAIL_PASSWORD = '55l0ngstr33tCT'
-    MAIL_DEFAULT_SENDER = 'proofs@hotink.co.za'
+    MAIL_USERNAME = os.environ.get('MAIL_USERNAME', 'proofs@hotink.co.za')
+    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD', '')
+    MAIL_DEFAULT_SENDER = MAIL_USERNAME
     PUBLIC_BASE_URL = 'https://upload.hotink.org.za'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,10 @@ services:
       - "5055:5055"
     volumes:
       - /mnt/nas_uploads:/mnt/nas_uploads
+    # Load sensitive values from the .env file
+    env_file:
+      - .env
     environment:
-      - SECRET_KEY=supersecret
+      - SECRET_KEY=${SECRET_KEY}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}


### PR DESCRIPTION
## Summary
- read mail username/password from environment variables
- show mail settings and .env usage in README
- expose the variables in docker-compose via `.env`

## Testing
- `python3 -m py_compile app.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_686cc94bf3f88327b51d8b350a40bf0f