### PR TITLE
Add pytest tests and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ MAIL_PASSWORD=your_password
 ```
 
 The `docker-compose.yml` file and `config.py` load these variables when running locally.
+
+## 🧪 Running Tests
+
+Install the dependencies and run the test suite with **pytest**:
+
+```bash
+pip install -r requirements.txt pytest
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import io
+import pytest
+from unittest.mock import MagicMock
+
+from app import app, mail
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+    upload_folder = tmp_path / "uploads"
+    upload_folder.mkdir()
+    csv_log = tmp_path / "upload_log.csv"
+
+    app.config['UPLOAD_FOLDER'] = str(upload_folder)
+    app.config['CSV_LOG'] = str(csv_log)
+
+    send_mock = MagicMock()
+    monkeypatch.setattr(mail, "send", send_mock)
+
+    with app.test_client() as client:
+        yield client, send_mock, csv_log, upload_folder

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,34 @@
+import io
+import pandas as pd
+
+def test_file_upload(app_client):
+    client, send_mock, csv_log, upload_folder = app_client
+
+    data = {
+        'designer': 'Andrew',
+        'client_name': 'Tester',
+        'email': 'tester@example.com',
+        'contact': '123456',
+        'instructions': 'Just testing'
+    }
+
+    data['file'] = (io.BytesIO(b'hello'), 'hello.txt')
+
+    response = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert response.get_json() == {'message': 'success'}
+
+    # File saved
+    assert (upload_folder / 'hello.txt').exists()
+
+    # CSV log updated
+    df = pd.read_csv(csv_log)
+    assert df.iloc[0]['Client Name'] == 'Tester'
+    assert df.iloc[0]['Files'] == 'hello.txt'
+
+    # Email sent
+    send_mock.assert_called_once()
+    msg = send_mock.call_args.args[0]
+    assert 'Tester' in msg.subject
+    assert msg.recipients == ['andrew@hotink.co.za']
+    assert 'hello.txt' in msg.body


### PR DESCRIPTION
## Summary
- add pytest fixtures and upload test
- document running tests in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_686cca75068883279d1405a357d7b08b