### PR TITLE
Ensure unique filenames

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from flask import Flask, render_template, request, jsonify
 from flask_mail import Mail, Message
 from werkzeug.utils import secure_filename
 from datetime import datetime
+import uuid
 from config import Config
 
 app = Flask(__name__)
@@ -38,15 +39,18 @@ def upload_files():
         "production@hotink.co.za"
     )
 
-    uploaded_files = []
+    uploaded_files = []  # list of saved unique filenames
+    original_files = []  # keep originals for reference if needed
     files = request.files.getlist('file')
 
     for file in files:
         if file.filename != "":
-            filename = secure_filename(file.filename)
-            save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            original_name = secure_filename(file.filename)
+            unique_name = f"{uuid.uuid4().hex}_{original_name}"
+            save_path = os.path.join(app.config['UPLOAD_FOLDER'], unique_name)
             file.save(save_path)
-            uploaded_files.append(filename)
+            uploaded_files.append(unique_name)
+            original_files.append(original_name)
 
     # Log upload
     log_upload(

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,17 +18,21 @@ def test_file_upload(app_client):
     assert response.status_code == 200
     assert response.get_json() == {'message': 'success'}
 
-    # File saved
-    assert (upload_folder / 'hello.txt').exists()
+    # File saved with unique name
+    files = list(upload_folder.iterdir())
+    assert len(files) == 1
+    saved_name = files[0].name
+    assert saved_name.endswith('hello.txt')
+    assert saved_name != 'hello.txt'
 
     # CSV log updated
     df = pd.read_csv(csv_log)
     assert df.iloc[0]['Client Name'] == 'Tester'
-    assert df.iloc[0]['Files'] == 'hello.txt'
+    assert df.iloc[0]['Files'] == saved_name
 
     # Email sent
     send_mock.assert_called_once()
     msg = send_mock.call_args.args[0]
     assert 'Tester' in msg.subject
     assert msg.recipients == ['andrew@hotink.co.za']
-    assert 'hello.txt' in msg.body
+    assert saved_name in msg.body


### PR DESCRIPTION
## Summary
- save each upload with a UUID-based name
- adjust tests for the new unique filename behavior

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ccbfa2b9c832795d30ab94dc9e367