### PR TITLE
Fix theme toggle to use data-theme attribute

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="light">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -44,10 +44,10 @@
   <script>
     document.getElementById('toggle-theme').addEventListener('click', () => {
       const html = document.documentElement;
-      if (html.getAttribute('data-bs-theme') === 'dark') {
-        html.setAttribute('data-bs-theme', 'light');
+      if (html.getAttribute('data-theme') === 'dark') {
+        html.setAttribute('data-theme', 'light');
       } else {
-        html.setAttribute('data-bs-theme', 'dark');
+        html.setAttribute('data-theme', 'dark');
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- update base HTML template to use the `data-theme` attribute
- adjust JavaScript that toggles dark mode
- CSS already relies on `[data-theme="dark"]` selectors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_686cd854cdec8327bc0fb0fb0f796740