### PR TITLE
Fix import path for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import io
+import os
+import sys
 import pytest
 from unittest.mock import MagicMock
+
+# Ensure the project root is on the import path so that ``app`` can be
+# imported when the tests are executed from arbitrary working
+# directories.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import app, mail
 


### PR DESCRIPTION
## Summary
- modify `tests/conftest.py` to ensure the repository root is in `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cdacbf948832784d481a243bba640