### PR TITLE
Update README bullet for full-page upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple, styled file uploader built in Flask to route design files directly to 
 - 📧 Auto-email notification to selected designer
 - 🗂️ Upload log saved as CSV for tracking
 - 📁 Files stored on `/mnt/nas_uploads` (or mounted volume)
-- 🎨 Modal-based upload form with themed progress bar
+- 🎨 Full-page upload interface with themed progress bar
 - 🧠 Configurable via `config.py` or Docker environment
 
 ---


### PR DESCRIPTION
## Summary
- update feature bullet to note full-page upload interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Flask)*

------
https://chatgpt.com/codex/tasks/task_e_686cdec7618483278a9a3cbd6509453f