### PR TITLE
Add form validity check before upload

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -96,7 +96,12 @@ const myDropzone = new Dropzone("#dropzone", {
 
     document.querySelector("#uploadForm").addEventListener("submit", function(e) {
       e.preventDefault();
-      const formData = new FormData(e.target);
+      const form = e.target;
+      if (!form.reportValidity()) {
+        return;
+      }
+
+      const formData = new FormData(form);
       dz.options.params = Object.fromEntries(formData);
       dz.processQueue();
     });


### PR DESCRIPTION
## Summary
- only process the Dropzone queue if the form passes HTML5 validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cded1c1bc83279ca1628de8be6e6a