### PR TITLE
Add upload button and adjust form style

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -9,7 +9,7 @@
     <p class="text-muted">Files are securely sent to your selected designer. Please fill in your details below.</p>
   </div>
 
-  <form id="uploadForm" class="bg-dark p-4 rounded shadow-sm">
+  <form id="uploadForm" class="p-4 rounded shadow-sm" style="background-color: #2c2f36;">
     <div class="form-group mb-3">
       <label class="text-white">Designer</label>
       <select class="form-control" name="designer" required>
@@ -38,6 +38,8 @@
 
   <!-- Dropzone -->
   <div id="dropzone" class="dropzone mt-3 border border-info rounded"></div>
+
+  <button id="startUploadBtn" type="button" class="btn btn-primary mt-3">Start Upload</button>
 
   <!-- Progress Bar -->
   <div class="progress mt-4" style="height: 20px; display: none;" id="uploadProgress">
@@ -108,7 +110,8 @@ const myDropzone = new Dropzone("#dropzone", {
   }
 });
 
-myDropzone.on("addedfile", function() {
+document.getElementById("startUploadBtn").addEventListener("click", function(e) {
+  e.preventDefault();
   document.querySelector("#uploadForm").dispatchEvent(new Event('submit'));
 });
 </script>


### PR DESCRIPTION
## Summary
- add a 'Start Upload' button for manual upload
- style form with dark gray background
- wire button to Dropzone uploader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686ce0fa2fa48327b7276d2583dc9be0