### PR TITLE
Add upload form theme styles

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -109,6 +109,14 @@ select#categoryFilter {
   min-width: 200px;
 }
 
+#uploadForm {
+  background-color: var(--light-card);
+}
+
+[data-theme="dark"] #uploadForm {
+  background-color: var(--dark-card);
+}
+
 @media (max-width: 576px) {
   .navbar .text-center {
     flex-direction: column;

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -9,7 +9,7 @@
     <p class="text-muted">Files are securely sent to your selected designer. Please fill in your details below.</p>
   </div>
 
-  <form id="uploadForm" class="p-4 rounded shadow-sm" style="background-color: #2c2f36;">
+  <form id="uploadForm" class="p-4 rounded shadow-sm">
     <div class="form-group mb-3">
       <label class="text-white">Designer</label>
       <select class="form-control" name="designer" required>


### PR DESCRIPTION
## Summary
- style upload form for light and dark modes
- remove outdated inline background color

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686ce5ea244c83279deb946431cc8e27