### PR TITLE
Improve upload form styling

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -109,14 +109,24 @@ select#categoryFilter {
   min-width: 200px;
 }
 
+[data-theme="light"] #uploadForm,
 #uploadForm {
-  background-color: var(--light-card);
+  background-color: #f2f2f2;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 [data-theme="dark"] #uploadForm {
   background-color: var(--dark-card);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.5);
+}
+
+@media (max-width: 768px) {
+  #uploadForm {
+    width: 100%;
+  }
 }
 
 .upload-note {


### PR DESCRIPTION
## Summary
- style upload form to half page width and center it
- use light gray form background in light mode
- keep dark mode as-is and add mobile width fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cebe488e48327b4d01f041582d0b5