### PR TITLE
Replace pandas in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask==2.2.5
 Flask-Mail==0.9.1
-pandas==2.2.2

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,5 @@
 import io
-import pandas as pd
+import csv
 from flask import url_for
 from app import app
 
@@ -28,9 +28,11 @@ def test_file_upload(app_client):
     assert saved_name != 'hello.txt'
 
     # CSV log updated
-    df = pd.read_csv(csv_log)
-    assert df.iloc[0]['Client Name'] == 'Tester'
-    assert df.iloc[0]['Files'] == saved_name
+    with open(csv_log, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+    assert rows[0]['Client Name'] == 'Tester'
+    assert rows[0]['Files'] == saved_name
 
     # Email sent
     send_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- remove pandas usage from the upload tests
- parse CSV log with the standard `csv` module
- drop pandas from `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cff9e47488327a3125a06f4bb54b1