### PR TITLE
Center Dropzone and upload button

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -129,6 +129,26 @@ select#categoryFilter {
   }
 }
 
+/* Centered dropzone to match the upload form */
+#dropzone {
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (max-width: 768px) {
+  #dropzone {
+    width: 100%;
+  }
+}
+
+/* Center the start upload button */
+#startUploadBtn {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .upload-note {
   font-size: 1.3rem;
   color: #343a40 !important;

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -41,9 +41,9 @@
   </form>
 
   <!-- Dropzone -->
-  <div id="dropzone" class="dropzone mt-3 border border-info rounded"></div>
+  <div id="dropzone" class="dropzone mt-3 border border-info rounded mx-auto"></div>
 
-  <button id="startUploadBtn" type="button" class="btn btn-primary mt-3">Start Upload</button>
+  <button id="startUploadBtn" type="button" class="btn btn-primary mt-3 d-block mx-auto">Start Upload</button>
 
   <!-- Progress Bar -->
   <div class="progress mt-4" style="height: 20px; display: none;" id="uploadProgress">


### PR DESCRIPTION
## Summary
- center the dropzone and start upload button
- keep both elements the same width as the upload form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d010ae1288327b337f115081a0ed8