### PR TITLE
Enable dark mode by default and tweak layout

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -33,6 +33,14 @@ body {
   font-size: 1.4286rem; /* Keep header text at original size */
 }
 
+#navbarBrand {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2rem;
+  font-weight: 700;
+}
+
 [data-theme="dark"] .navbar {
   background-color: var(--dark-card);
   font-size: 1.4286rem;
@@ -123,6 +131,14 @@ select#categoryFilter {
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.5);
 }
 
+#uploadForm label {
+  color: #343a40;
+}
+
+[data-theme="dark"] #uploadForm label {
+  color: var(--text-dark);
+}
+
 @media (max-width: 768px) {
   #uploadForm {
     width: 100%;
@@ -147,6 +163,8 @@ select#categoryFilter {
   display: block;
   margin-left: auto;
   margin-right: auto;
+  font-size: 1.25rem;
+  padding: 0.75rem 2rem;
 }
 
 .upload-note {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -20,8 +20,8 @@
 <body>
 
   <header class="navbar navbar-expand-lg bg-primary sticky-top">
-    <div class="container-fluid">
-      <a class="navbar-brand d-flex align-items-center" href="#">
+    <div class="container-fluid position-relative">
+      <a id="navbarBrand" class="navbar-brand d-flex align-items-center" href="#">
         <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Logo" height="50" class="me-2">
         Hot Ink Artwork Portal
       </a>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -15,7 +15,7 @@
            src="{{ url_for('static', filename=designers[0].avatar) if designers else url_for('static', filename='images/designers/default_avatar.png') }}" alt="Designer Avatar">
     </div>
     <div class="form-group mb-3">
-      <label class="text-white">Designer</label>
+      <label>Designer</label>
       <select id="designerSelect" class="form-control" name="designer" required>
         {% for d in designers %}
         <option value="{{ d.name }}" data-avatar="{{ url_for('static', filename=d.avatar) }}">{{ d.name }}</option>
@@ -23,19 +23,19 @@
       </select>
     </div>
     <div class="form-group mb-3">
-      <label class="text-white">Your Name</label>
+      <label>Your Name</label>
       <input type="text" class="form-control" name="client_name" required>
     </div>
     <div class="form-group mb-3">
-      <label class="text-white">Email</label>
+      <label>Email</label>
       <input type="email" class="form-control" name="email" required>
     </div>
     <div class="form-group mb-3">
-      <label class="text-white">Contact</label>
+      <label>Contact</label>
       <input type="text" class="form-control" name="contact" required>
     </div>
     <div class="form-group mb-3">
-      <label class="text-white">Instructions</label>
+      <label>Instructions</label>
       <textarea class="form-control" name="instructions" rows="3"></textarea>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- default to dark theme in the base template
- center and enlarge the navbar brand
- tone down label colors in light mode
- enlarge the upload button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d042ec7d483278a71b8b7b2afe18c