### PR TITLE
Add admin upload log viewer

### DIFF
--- a/app.py
+++ b/app.py
@@ -249,7 +249,20 @@ def admin():
             m = re.match(r"\s*(--[^:]+):\s*([^;]+);", line)
             if m:
                 variables[m.group(1)] = m.group(2)
-    return render_template('admin.html', designers=DESIGNERS, variables=variables)
+
+    log_entries = []
+    log_file = app.config['CSV_LOG']
+    if os.path.exists(log_file):
+        with open(log_file, newline='') as csvfile:
+            reader = csv.DictReader(csvfile)
+            log_entries = list(reader)
+
+    return render_template(
+        'admin.html',
+        designers=DESIGNERS,
+        variables=variables,
+        log_entries=log_entries,
+    )
 
 
 @app.route('/admin/avatar', methods=['POST'])

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -28,5 +28,31 @@
   <input type="text" name="value" class="form-control mb-2" placeholder="Value" required>
   <button class="btn btn-primary">Save</button>
 </form>
+
+<h3 class="mt-5">Upload Log</h3>
+{% if log_entries %}
+<div class="table-responsive">
+  <table class="table table-striped table-sm">
+    <thead>
+      <tr>
+        {% for h in log_entries[0].keys() %}
+        <th>{{ h }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+    {% for row in log_entries %}
+      <tr>
+        {% for val in row.values() %}
+        <td>{{ val }}</td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p>No uploads yet.</p>
+{% endif %}
 <a href="{{ url_for('admin_logout') }}" class="btn btn-link mt-3">Logout</a>
 {% endblock %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -44,3 +44,34 @@ def test_theme_update(app_client):
     new_content = css_path.read_text()
     assert '#000000' in new_content
     assert original != new_content
+
+
+def test_upload_log_display(app_client):
+    client, _, csv_log, _ = app_client
+    login(client)
+
+    import csv
+    with open(csv_log, 'w', newline='') as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                'Date', 'Designer', 'Client Name', 'Email',
+                'Contact', 'Instructions', 'Files'
+            ],
+        )
+        writer.writeheader()
+        writer.writerow({
+            'Date': '2024-01-01',
+            'Designer': 'Andrew',
+            'Client Name': 'Tester',
+            'Email': 't@example.com',
+            'Contact': '123',
+            'Instructions': 'hi',
+            'Files': 'file1.txt',
+        })
+
+    resp = client.get('/admin')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'file1.txt' in html
+    assert 'Tester' in html


### PR DESCRIPTION
## Summary
- load `upload_log.csv` and pass log entries to the admin template
- render a responsive table showing uploads in `admin.html`
- test that uploaded log data is visible after login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d156d3d388327a13c785fa40c3814