### PR TITLE
Include upload paths in notification emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Create a `.env` file with:
 SECRET_KEY=supersecret
 MAIL_USERNAME=proofs@hotink.co.za
 MAIL_PASSWORD=your_password
+FILE_SERVER_PATH=NAS/_Temp Work/ClientFiles
 ```
 
 The `docker-compose.yml` file and `config.py` load these variables when running locally.

--- a/app.py
+++ b/app.py
@@ -206,6 +206,9 @@ def send_notification(designer_email, name, email, contact, instructions, files)
         subject=f"New Artwork Upload from {name}",
         recipients=[designer_email]
     )
+    file_paths = [
+        os.path.join(app.config['FILE_SERVER_PATH'], f) for f in files
+    ]
     body = f"""
 New artwork uploaded:
 
@@ -218,7 +221,7 @@ Files:
 {chr(10).join(files)}
 
 Location on server:
-/mnt/nas_uploads
+{chr(10).join(file_paths)}
 """
     msg.body = body
     mail.send(msg)

--- a/config.py
+++ b/config.py
@@ -27,3 +27,8 @@ class Config:
     CSS_FILE = os.environ.get(
         'CSS_FILE', os.path.join('static', 'css', 'dashboard.css')
     )
+
+    # Base path shown in notification emails for uploaded files
+    FILE_SERVER_PATH = os.environ.get(
+        'FILE_SERVER_PATH', 'NAS/_Temp Work/ClientFiles'
+    )


### PR DESCRIPTION
## Summary
- support configurable file share path
- include uploaded file names and their server locations when notifying designers
- document `FILE_SERVER_PATH` environment variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d16dc0ea4832780149c33d83a2281