### PR TITLE
Use app.config for file server path

### DIFF
--- a/app.py
+++ b/app.py
@@ -208,7 +208,7 @@ def send_notification(designer_email, name, email, contact, instructions, files,
         recipients=[designer_email]
     )
     file_paths = [
-        os.path.join(Config.FILE_SERVER_PATH, f) for f in files
+        os.path.join(app.config['FILE_SERVER_PATH'], f) for f in files
     ]
 
     body = f"""

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -3,7 +3,6 @@ import os
 import csv
 from flask import url_for
 from app import app
-from config import Config
 
 def test_file_upload(app_client):
     client, send_mock, csv_log, upload_folder = app_client
@@ -58,7 +57,7 @@ def test_designer_avatars_in_template(app_client):
 def test_notification_includes_file_server_path(app_client, monkeypatch):
     client, send_mock, _, upload_folder = app_client
 
-    monkeypatch.setattr(Config, 'FILE_SERVER_PATH', '/srv/files')
+    app.config['FILE_SERVER_PATH'] = '/srv/files'
 
     data = {
         'designer': 'Andrew',


### PR DESCRIPTION
## Summary
- read `FILE_SERVER_PATH` from `app.config` when composing notification emails
- update tests to configure this value through `app.config`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d211a83248327964acff6f22968a8