### PR TITLE
Refactor email location text

### DIFF
--- a/app.py
+++ b/app.py
@@ -210,9 +210,7 @@ def send_notification(designer_email, name, email, contact, instructions, files,
         subject=f"New Artwork Upload from {name}",
         recipients=[designer_email]
     )
-    file_paths = [
-        os.path.join(app.config['FILE_SERVER_PATH'], f) for f in files
-    ]
+    location = app.config['FILE_SERVER_PATH']
 
     body = f"""
 New artwork uploaded:
@@ -226,7 +224,7 @@ Files:
 {chr(10).join(originals)}
 
 Location on server:
-{chr(10).join(file_paths)}
+{location}
 """
     msg.body = body
     mail.send(msg)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -71,7 +71,5 @@ def test_notification_includes_file_server_path(app_client, monkeypatch):
     response = client.post('/upload', data=data, content_type='multipart/form-data')
     assert response.status_code == 200
 
-    saved_name = next(upload_folder.iterdir()).name
-    expected_path = os.path.join('/srv/files', saved_name)
     msg = send_mock.call_args.args[0]
-    assert expected_path in msg.body
+    assert '/srv/files' in msg.body


### PR DESCRIPTION
## Summary
- simplify server location text in send_notification
- adjust tests for new email body format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686dfe3adc2483279c8aa49f58bf32f6